### PR TITLE
Refactor chatbot to use GenAI ChatSession for history and context

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -79,14 +79,13 @@ func newMessage(discord *discordgo.Session, message *discordgo.MessageCreate) {
 
 	isPrivateChannel := message.GuildID == ""
 
-	userID := message.Author.ID
-	conversationHistory := conversationHistoryMap[userID]
-
-	channelID := message.ChannelID
-	conversationHistory = populateConversationHistory(discord, channelID, conversationHistory)
+	// The userID and conversationHistoryMap are no longer used here for chatGPT history.
+	// channelID := message.ChannelID // This variable is not used after removing populateConversationHistory
 
 	if strings.HasPrefix(message.Content, "!bit") || isPrivateChannel {
-		chatGPT(discord, message.ChannelID, conversationHistory)
+		// Call chatGPT with the Discord session, channel ID, and the message content directly.
+		// History is now managed within chatGPT using a global session and fetching from Discord if needed.
+		chatGPT(discord, message.ChannelID, message.Content)
 	}
 }
 


### PR DESCRIPTION
This commit refactors the chatbot's conversation management to align with GenAI SDK best practices.

Key changes:
- Introduced `genai.ChatSession` in `bot/chat.go` to manage conversation history, context, and system instructions.
- Modified `chatGPT` function:
    - It now initializes and uses a global `currentChatSession`.
    - When a new session starts for a Discord channel, `chatGPT` fetches recent messages from that channel and populates the `ChatSession` history.
    - New messages are sent via `ChatSession.SendMessage()`, which also handles adding user and model messages to the history.
    - The function signature was updated to `chatGPT(session *discordgo.Session, channelID string, userMessageContent string)`.
- Created `prepareMessageForHistory` to format individual messages into `*genai.Content` for the chat history.
- Updated the `newMessage` function in `bot/bot.go` to call `chatGPT` with its new signature and removed the old manual history population logic.
- Ensured `InitGeminiClient` correctly sets the `SystemInstruction` on the generative model.

These changes replace the previous manual history management (using `populateConversationHistory` and `conversationHistoryMap`) with the more robust and idiomatic `ChatSession` from the GenAI SDK, improving context retention and adherence to library specifications.