### PR TITLE
Add reminder functionality with slash commands

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -1,7 +1,7 @@
 package bot
 
 import (
-	"bitbot/pb"
+	"bitbot/pb"       // PocketBase interaction
 	"context"         // For GenAI client
 	"encoding/binary" // For PCM to byte conversion
 	"errors"          // For error handling
@@ -16,6 +16,8 @@ import (
 	"github.com/charmbracelet/log"
 	"google.golang.org/api/option" // For GenAI client
 	"io"                           // For io.EOF in GenAI receive
+	"regexp"                       // For parsing time strings
+	"strconv"                      // For parsing time strings
 	"sync"                         // For RWMutex
 
 	"github.com/pion/opus"    // Opus decoding (switched from layeh/gopus)
@@ -27,6 +29,7 @@ import (
 )
 
 var (
+	// BotToken is injected at build time or via env
 	BotToken      string
 	GeminiAPIKey  string // This is already used by chat.go's InitGeminiClient
 	CryptoToken   string
@@ -34,6 +37,120 @@ var (
 	AppId         string
 
 	// ttsClient *texttospeech.Client // REMOVED
+)
+
+// Command definitions
+var (
+	commands = []*discordgo.ApplicationCommand{
+		{Name: "cry", Description: "Get information about cryptocurrency prices."},
+		{Name: "genkey", Description: "Generate and save SSH key pair."},
+		{Name: "showkey", Description: "Show the public SSH key."},
+		{Name: "regenkey", Description: "Regenerate and save SSH key pair."},
+		{Name: "createevent", Description: "Organize an Ava dungeon raid event."},
+		{
+			Name:        "ssh",
+			Description: "Connect to a remote server via SSH.",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        "connection_details",
+					Description: "Connection details in the format username@remote-host:port",
+					Type:        discordgo.ApplicationCommandOptionString,
+					Required:    true,
+				},
+			},
+		},
+		{
+			Name:        "exe",
+			Description: "Execute a command on the remote server.",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        "command",
+					Description: "The command to execute.",
+					Type:        discordgo.ApplicationCommandOptionString,
+					Required:    true,
+				},
+			},
+		},
+		{Name: "exit", Description: "Close the SSH connection."},
+		{Name: "list", Description: "List saved servers."},
+		{
+			Name:        "help",
+			Description: "Show available commands.",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        "category",
+					Description: "Specify 'admin' to view admin commands.",
+					Type:        discordgo.ApplicationCommandOptionString,
+					Required:    false,
+				},
+			},
+		},
+		{
+			Name:        "roll",
+			Description: "Roll a random number.",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        "max",
+					Description: "Specify the maximum number for the roll.",
+					Type:        discordgo.ApplicationCommandOptionInteger,
+					Required:    false,
+				},
+			},
+		},
+		{
+			Name:        "remind",
+			Description: "Manage reminders.",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Name:        "add",
+					Description: "Add a new reminder.",
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "who",
+							Description: "User(s) to remind (mention or ID, comma-separated). Use '@me' for yourself.",
+							Required:    true,
+						},
+						{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "when",
+							Description: "When to send the reminder (e.g., 'in 10m', 'tomorrow 10am', 'every Mon 9am').",
+							Required:    true,
+						},
+						{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "message",
+							Description: "The reminder message.",
+							Required:    true,
+						},
+					},
+				},
+				{
+					Name:        "list",
+					Description: "List your active reminders.",
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+				},
+				{
+					Name:        "delete",
+					Description: "Delete a reminder by its ID.",
+					Type:        discordgo.ApplicationCommandOptionSubCommand,
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "id",
+							Description: "The ID of the reminder to delete (from /remind list).",
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+	// registeredCommands is a map to keep track of registered commands and avoid re-registering.
+	// This might be useful if registerCommands is called multiple times, though typically it's once at startup.
+	// For now, we'll assume it's called once and simply iterate through `commands`.
+	// var registeredCommands = make(map[string]*discordgo.ApplicationCommand)
 )
 
 func Run() {
@@ -68,6 +185,9 @@ func Run() {
 
 	userVoiceSessions = make(map[string]*UserVoiceSession)
 	log.Info("User voice sessions map initialized.")
+
+	// Start the reminder scheduler
+	go startReminderScheduler(discord)
 
 	// Initialize Google Cloud Text-to-Speech client - REMOVED
 	// ctx := context.Background()
@@ -128,68 +248,19 @@ func newMessage(discord *discordgo.Session, message *discordgo.MessageCreate) {
 }
 
 func registerCommands(discord *discordgo.Session, appID string) {
-	commands := []*discordgo.ApplicationCommand{
-		{Name: "cry", Description: "Get information about cryptocurrency prices."},
-		{Name: "genkey", Description: "Generate and save SSH key pair."},
-		{Name: "showkey", Description: "Show the public SSH key."},
-		{Name: "regenkey", Description: "Regenerate and save SSH key pair."},
-		{Name: "createevent", Description: "Organize an Ava dungeon raid event."},
-		{
-			Name:        "ssh",
-			Description: "Connect to a remote server via SSH.",
-			Options: []*discordgo.ApplicationCommandOption{
-				{
-					Name:        "connection_details",
-					Description: "Connection details in the format username@remote-host:port",
-					Type:        discordgo.ApplicationCommandOptionString,
-					Required:    true,
-				},
-			},
-		},
-		{
-			Name:        "exe",
-			Description: "Execute a command on the remote server.",
-			Options: []*discordgo.ApplicationCommandOption{
-				{
-					Name:        "command",
-					Description: "The command to execute.",
-					Type:        discordgo.ApplicationCommandOptionString,
-					Required:    true,
-				},
-			},
-		},
-		{Name: "exit", Description: "Close the SSH connection."},
-		{Name: "list", Description: "List saved servers."},
-		{
-			Name:        "help",
-			Description: "Show available commands.",
-			Options: []*discordgo.ApplicationCommandOption{
-				{
-					Name:        "category",
-					Description: "Specify 'admin' to view admin commands.",
-					Type:        discordgo.ApplicationCommandOptionString,
-					Required:    false,
-				},
-			},
-		},
-		{
-			Name:        "roll",
-			Description: "Roll a random number.",
-			Options: []*discordgo.ApplicationCommandOption{
-				{
-					Name:        "max",
-					Description: "Specify the maximum number for the roll.",
-					Type:        discordgo.ApplicationCommandOptionInteger,
-					Required:    false,
-				},
-			},
-		},
-	}
-
+	log.Infof("Registering %d commands.", len(commands))
+	// To register for a specific guild, use:
+	// discord.ApplicationCommandCreate(appID, "YOUR_GUILD_ID", cmd)
 	for _, cmd := range commands {
-		_, err := discord.ApplicationCommandCreate(appID, "", cmd)
+		_, err := discord.ApplicationCommandCreate(appID, "", cmd) // Registering globally
 		if err != nil {
 			log.Fatalf("Cannot create slash command %q: %v", cmd.Name, err)
+		}
+		log.Infof("Successfully registered command: %s", cmd.Name)
+	}
+}
+
+func joinVoiceChannel(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 	}
 }
@@ -1011,11 +1082,446 @@ func commandHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			}
 			result := rand.Intn(max) + 1
 			respondWithMessage(s, i, fmt.Sprintf("You rolled: %d", result))
+		case "remind":
+			// Delegate to a sub-handler for /remind subcommands
+			handleRemindCommand(s, i)
 		}
 	} else if i.Type == discordgo.InteractionModalSubmit {
 		modalHandler(s, i)
 	}
 }
+
+// handleRemindCommand delegates processing for /remind subcommands
+func handleRemindCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	subCommand := i.ApplicationCommandData().Options[0].Name
+	switch subCommand {
+	case "add":
+		handleAddReminder(s, i)
+	case "list":
+		handleListReminders(s, i)
+	case "delete":
+		handleDeleteReminder(s, i)
+	default:
+		respondWithMessage(s, i, "Unknown remind subcommand.")
+	}
+}
+
+// handleAddReminder processes the /remind add command.
+func handleAddReminder(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	options := i.ApplicationCommandData().Options[0].Options // Options for the "add" subcommand
+
+	var whoArg, whenArg, messageArg string
+	for _, opt := range options {
+		switch opt.Name {
+		case "who":
+			whoArg = opt.StringValue()
+		case "when":
+			whenArg = opt.StringValue()
+		case "message":
+			messageArg = opt.StringValue()
+		}
+	}
+
+	if whoArg == "" || whenArg == "" || messageArg == "" {
+		respondWithMessage(s, i, "Missing required arguments for adding a reminder.")
+		return
+	}
+
+	// 1. Parse 'who' argument
+	var targetUserIDs []string
+	rawTargetUserIDs := strings.Split(whoArg, ",")
+	for _, idStr := range rawTargetUserIDs {
+		trimmedID := strings.TrimSpace(idStr)
+		if trimmedID == "@me" {
+			targetUserIDs = append(targetUserIDs, i.Member.User.ID)
+		} else {
+			// Basic validation: check if it's a user mention or a raw ID
+			// <@USER_ID> or <@!USER_ID>
+			re := regexp.MustCompile(`<@!?(\d+)>`)
+			matches := re.FindStringSubmatch(trimmedID)
+			if len(matches) == 2 {
+				targetUserIDs = append(targetUserIDs, matches[1])
+			} else if _, err := strconv.ParseUint(trimmedID, 10, 64); err == nil {
+				// Looks like a raw ID
+				targetUserIDs = append(targetUserIDs, trimmedID)
+			} else {
+				respondWithMessage(s, i, fmt.Sprintf("Invalid user format: '%s'. Please use @mention, user ID, or '@me'.", trimmedID))
+				return
+			}
+		}
+	}
+	if len(targetUserIDs) == 0 {
+		respondWithMessage(s, i, "No valid target users specified.")
+		return
+	}
+	// Remove duplicates
+	seen := make(map[string]bool)
+	uniqueTargetUserIDs := []string{}
+	for _, id := range targetUserIDs {
+		if !seen[id] {
+			seen[id] = true
+			uniqueTargetUserIDs = append(uniqueTargetUserIDs, id)
+		}
+	}
+	targetUserIDs = uniqueTargetUserIDs
+
+
+	// 2. Parse 'when' argument (initial simple parsing)
+	// TODO: Expand this with more robust parsing (date, time, recurring)
+	reminderTime, isRecurring, recurrenceRule, err := parseWhenSimple(whenArg)
+	if err != nil {
+		respondWithMessage(s, i, fmt.Sprintf("Error parsing 'when' argument: %v. Supported formats: 'in Xm/Xh/Xd'", err))
+		return
+	}
+
+	// 3. Create Reminder struct
+	reminder := &pb.Reminder{
+		UserID:         i.Member.User.ID,
+		TargetUserIDs:  targetUserIDs,
+		Message:        messageArg,
+		ChannelID:      i.ChannelID,
+		GuildID:        i.GuildID, // Will be empty for DMs, which is fine
+		ReminderTime:   reminderTime,
+		IsRecurring:    isRecurring,
+		RecurrenceRule: recurrenceRule,
+	}
+	// For non-recurring, NextReminderTime is same as ReminderTime initially by GetDueReminders logic.
+	// For recurring, NextReminderTime should be the first actual occurrence.
+	// Our simple parser sets ReminderTime to the first occurrence.
+	// If it's recurring, we'll set NextReminderTime to this first occurrence.
+	if isRecurring {
+		reminder.NextReminderTime = reminderTime
+	}
+
+
+	// 4. Save to PocketBase
+	err = pb.CreateReminder(reminder)
+	if err != nil {
+		log.Errorf("Failed to create reminder: %v", err)
+		respondWithMessage(s, i, "Sorry, I couldn't save your reminder. Please try again later.")
+		return
+	}
+
+	// 5. Confirm to user
+	var targetUsersString []string
+	for _, uid := range targetUserIDs {
+		targetUsersString = append(targetUsersString, fmt.Sprintf("<@%s>", uid))
+	}
+
+	timeFormat := "Jan 2, 2006 at 3:04 PM MST"
+	confirmationMsg := fmt.Sprintf("Okay, I'll remind %s on %s about: \"%s\"",
+		strings.Join(targetUsersString, ", "),
+		reminderTime.Local().Format(timeFormat), // Display in local time for confirmation
+		messageArg)
+	if isRecurring {
+		confirmationMsg += fmt.Sprintf(" (recurs %s)", recurrenceRule)
+	}
+
+	respondWithMessage(s, i, confirmationMsg)
+}
+
+// parseWhenSimple is a basic parser for "in Xm/h/d" and "every Xm/h/d" type strings.
+// Returns: reminderTime, isRecurring, recurrenceRule, error
+func parseWhenSimple(whenStr string) (time.Time, bool, string, error) {
+	whenStr = strings.ToLower(strings.TrimSpace(whenStr))
+	now := time.Now()
+	isRecurring := false
+	recurrenceRule := ""
+
+	// Check for "every" keyword for recurrence
+	if strings.HasPrefix(whenStr, "every ") {
+		isRecurring = true
+		whenStr = strings.TrimPrefix(whenStr, "every ")
+		// For simple "every Xunit", the rule is just the unit for now.
+		// More complex parsing will set a better rule.
+	}
+
+	// Regex for "in Xunit" or "Xunit"
+	// Example: "in 10m", "10m", "in 2h", "2h", "in 3d", "3d"
+	re := regexp.MustCompile(`^(?:in\s+)?(\d+)\s*([mhd])$`)
+	matches := re.FindStringSubmatch(whenStr)
+
+	if len(matches) == 3 {
+		value, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return time.Time{}, false, "", fmt.Errorf("invalid number: %s", matches[1])
+		}
+		unit := matches[2]
+		duration := time.Duration(value)
+
+		switch unit {
+		case "m":
+			duration *= time.Minute
+			if isRecurring { recurrenceRule = fmt.Sprintf("every %d minutes", value) }
+		case "h":
+			duration *= time.Hour
+			if isRecurring { recurrenceRule = fmt.Sprintf("every %d hours", value) }
+		case "d":
+			duration *= time.Hour * 24
+			if isRecurring { recurrenceRule = fmt.Sprintf("every %d days", value) }
+		default:
+			return time.Time{}, false, "", fmt.Errorf("unknown time unit: %s", unit)
+		}
+
+		if isRecurring && recurrenceRule == "" { // Should be set by above cases
+			return time.Time{}, false, "", fmt.Errorf("could not determine recurrence rule for: %s", whenStr)
+		}
+
+		return now.Add(duration), isRecurring, recurrenceRule, nil
+	}
+
+	// TODO: Add more parsing logic here (e.g., "tomorrow at 10am", "next Monday at 3pm", "every day at 9am")
+	// For now, only "in Xm/h/d" is supported for non-recurring.
+	// And "every Xm/h/d" for recurring.
+	if isRecurring {
+		return time.Time{}, false, "", fmt.Errorf("unsupported recurring format: '%s'. Try 'every Xm/Xh/Xd'", whenStr)
+	}
+	return time.Time{}, false, "", fmt.Errorf("unsupported time format: '%s'. Try 'in Xm/Xh/Xd'", whenStr)
+}
+
+
+func handleListReminders(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	userID := i.Member.User.ID
+	reminders, err := pb.ListRemindersByUser(userID)
+	if err != nil {
+		log.Errorf("Failed to list reminders for user %s: %v", userID, err)
+		respondWithMessage(s, i, "Could not fetch your reminders. Please try again later.")
+		return
+	}
+
+	if len(reminders) == 0 {
+		respondWithMessage(s, i, "You have no active reminders.")
+		return
+	}
+
+	var response strings.Builder
+	response.WriteString("**Your active reminders:**\n")
+	timeFormat := "Jan 2, 2006 at 3:04 PM MST"
+
+	for idx, r := range reminders {
+		var nextDue time.Time
+		if r.IsRecurring {
+			nextDue = r.NextReminderTime
+		} else {
+			nextDue = r.ReminderTime
+		}
+
+		// Ensure we have a valid time to format
+		var nextDueStr string
+		if !nextDue.IsZero() {
+			nextDueStr = nextDue.Local().Format(timeFormat)
+		} else {
+			nextDueStr = "N/A (Error in time)" // Should ideally not happen with current logic
+		}
+
+		var targets []string
+		for _, tUID := range r.TargetUserIDs {
+			if tUID == userID {
+				targets = append(targets, "@me")
+			} else {
+				targets = append(targets, fmt.Sprintf("<@%s>", tUID))
+			}
+		}
+		targetStr := strings.Join(targets, ", ")
+
+		response.WriteString(fmt.Sprintf("%d. **ID**: `%s`\n", idx+1, r.ID))
+		response.WriteString(fmt.Sprintf("   **To**: %s\n", targetStr))
+		response.WriteString(fmt.Sprintf("   **Message**: %s\n", r.Message))
+		response.WriteString(fmt.Sprintf("   **Next Due**: %s\n", nextDueStr))
+		if r.IsRecurring {
+			response.WriteString(fmt.Sprintf("   **Recurs**: %s\n", r.RecurrenceRule))
+		}
+		response.WriteString("\n")
+	}
+
+	// Discord messages have a length limit (usually 2000 characters).
+	// If the list is too long, we might need to paginate or send in multiple messages.
+	// For now, send as one, assuming it won't be excessively long for typical use.
+	if response.Len() > 1900 { // Leave some buffer
+		respondWithMessage(s, i, "You have too many reminders to display in one message. Please delete some old ones if possible. (Full list display for very long lists is a TODO)")
+		return
+	}
+
+	respondWithMessage(s, i, response.String())
+}
+
+func handleDeleteReminder(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	deleterUserID := i.Member.User.ID
+	reminderIDToDelete := i.ApplicationCommandData().Options[0].Options[0].StringValue() // Subcommand "delete" -> option "id"
+
+	if reminderIDToDelete == "" {
+		respondWithMessage(s, i, "You must provide a reminder ID to delete.")
+		return
+	}
+
+	reminder, err := pb.GetReminderByID(reminderIDToDelete)
+	if err != nil {
+		// Check if it's a "not found" error
+		if strings.Contains(err.Error(), "Failed to find record") || strings.Contains(err.Error(), "not found") { // Adjust based on PocketBase error messages
+			log.Warnf("User %s tried to delete non-existent reminder ID %s: %v", deleterUserID, reminderIDToDelete, err)
+			respondWithMessage(s, i, fmt.Sprintf("Could not find a reminder with ID: `%s`.", reminderIDToDelete))
+			return
+		}
+		log.Errorf("Error fetching reminder ID %s for deletion by user %s: %v", reminderIDToDelete, deleterUserID, err)
+		respondWithMessage(s, i, "Could not fetch the reminder for deletion. Please try again.")
+		return
+	}
+
+	// Authorization: Check if the user trying to delete is the one who created it.
+	// TODO: Add admin override if desired (e.g., check for admin role)
+	if reminder.UserID != deleterUserID {
+		log.Warnf("User %s attempted to delete reminder ID %s owned by user %s.", deleterUserID, reminderIDToDelete, reminder.UserID)
+		respondWithMessage(s, i, "You can only delete reminders that you created.")
+		return
+	}
+
+	err = pb.DeleteReminder(reminderIDToDelete)
+	if err != nil {
+		log.Errorf("Failed to delete reminder ID %s for user %s: %v", reminderIDToDelete, deleterUserID, err)
+		respondWithMessage(s, i, fmt.Sprintf("Failed to delete reminder `%s`. Please try again.", reminderIDToDelete))
+		return
+	}
+
+	log.Infof("User %s successfully deleted reminder ID %s.", deleterUserID, reminderIDToDelete)
+	respondWithMessage(s, i, fmt.Sprintf("Successfully deleted reminder with ID: `%s`.", reminderIDToDelete))
+}
+
+// startReminderScheduler periodically checks for and dispatches due reminders.
+func startReminderScheduler(s *discordgo.Session) {
+	log.Info("Starting reminder scheduler...")
+	// Check every minute. Adjust ticker duration as needed.
+	// For testing, a shorter duration might be used, but 1 minute is reasonable for production.
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			log.Debug("Reminder scheduler ticked. Checking for due reminders...")
+			processDueReminders(s)
+		}
+	}
+}
+
+// processDueReminders fetches and handles due reminders.
+func processDueReminders(s *discordgo.Session) {
+	dueReminders, err := pb.GetDueReminders()
+	if err != nil {
+		log.Errorf("Error fetching due reminders: %v", err)
+		return
+	}
+
+	if len(dueReminders) == 0 {
+		log.Debug("No due reminders found.")
+		return
+	}
+
+	log.Infof("Found %d due reminder(s). Processing...", len(dueReminders))
+
+	for _, reminder := range dueReminders {
+		var mentions []string
+		for _, userID := range reminder.TargetUserIDs {
+			mentions = append(mentions, fmt.Sprintf("<@%s>", userID))
+		}
+		fullMessage := fmt.Sprintf("%s Hey! Here's your reminder: %s", strings.Join(mentions, " "), reminder.Message)
+
+		_, err := s.ChannelMessageSend(reminder.ChannelID, fullMessage)
+		if err != nil {
+			log.Errorf("Failed to send reminder message for reminder ID %s to channel %s: %v", reminder.ID, reminder.ChannelID, err)
+			// Decide if we should retry or skip. For now, skip.
+			// If the channel or bot permissions are an issue, retrying might not help.
+			continue
+		}
+		log.Infof("Sent reminder ID %s to channel %s for users %v.", reminder.ID, reminder.ChannelID, reminder.TargetUserIDs)
+
+		if !reminder.IsRecurring {
+			err := pb.DeleteReminder(reminder.ID)
+			if err != nil {
+				log.Errorf("Failed to delete non-recurring reminder ID %s: %v", reminder.ID, err)
+			} else {
+				log.Infof("Deleted non-recurring reminder ID %s.", reminder.ID)
+			}
+		} else {
+			// Handle recurring reminder: calculate next time and update
+			nextTime, errCalc := calculateNextRecurrence(reminder.ReminderTime, reminder.RecurrenceRule, reminder.LastTriggeredAt)
+			if errCalc != nil {
+				log.Errorf("Failed to calculate next recurrence for reminder ID %s: %v. Deleting reminder to prevent loop.", reminder.ID, errCalc)
+				// If calculation fails, delete it to avoid it getting stuck.
+				pb.DeleteReminder(reminder.ID)
+				continue
+			}
+
+			reminder.NextReminderTime = nextTime
+			reminder.LastTriggeredAt = time.Now().UTC() // Set last triggered to now
+
+			errUpdate := pb.UpdateReminder(reminder)
+			if errUpdate != nil {
+				log.Errorf("Failed to update recurring reminder ID %s with next time %v: %v", reminder.ID, nextTime, errUpdate)
+			} else {
+				log.Infof("Updated recurring reminder ID %s. Next occurrence: %s", reminder.ID, nextTime.Format(time.RFC1123))
+			}
+		}
+	}
+}
+
+// calculateNextRecurrence calculates the next time for a recurring reminder.
+// This is a simplified version based on parseWhenSimple's output.
+// TODO: Enhance this to parse more complex RecurrenceRule (e.g., cron strings, specific days).
+func calculateNextRecurrence(originalReminderTime time.Time, rule string, lastTriggeredTime time.Time) (time.Time, error) {
+	now := time.Now()
+	// If lastTriggeredTime is zero (first time for a recurring one after initial setup),
+	// or if originalReminderTime is in the future (e.g. reminder set "every day at 9am" but it's 8am now),
+	// the next time *might* still be the originalReminderTime if it hasn't passed.
+	// However, GetDueReminders should only return it if originalReminderTime/NextReminderTime is past.
+	// So, we assume lastTriggeredTime is the correct base if available and non-zero.
+
+	baseTime := lastTriggeredTime
+	if baseTime.IsZero() { // If it was never triggered (e.g. just created recurring)
+		baseTime = originalReminderTime // This was the first scheduled time.
+	}
+
+	// Ensure baseTime is not in the future relative to now, as we're calculating the *next* one from *now* or *last trigger*.
+    // If the calculated baseTime (original or last triggered) is somehow ahead of 'now',
+    // and it was picked by GetDueReminders, it means 'now' just passed it.
+    // So, the next occurrence should be calculated from this 'baseTime'.
+
+	// Simple rules from parseWhenSimple: "every X minutes/hours/days"
+	re := regexp.MustCompile(`^every (\d+) (minutes|hours|days)$`)
+	matches := re.FindStringSubmatch(strings.ToLower(rule))
+
+	if len(matches) == 3 {
+		value, err := strconv.Atoi(matches[1])
+		if err != nil {
+			// This should ideally not happen due to the regex \d+
+			return time.Time{}, fmt.Errorf("internal error parsing number from rule '%s': %v", rule, err)
+		}
+		unit := matches[2]
+		var durationToAdd time.Duration
+
+		switch unit {
+		case "minutes":
+			durationToAdd = time.Duration(value) * time.Minute
+		case "hours":
+			durationToAdd = time.Duration(value) * time.Hour
+		case "days":
+			durationToAdd = time.Duration(value) * time.Hour * 24
+		default:
+			return time.Time{}, fmt.Errorf("unknown unit in recurrence rule: %s", unit)
+		}
+
+		next := baseTime.Add(durationToAdd)
+        // Ensure the next calculated time is in the future from 'now'.
+        // If baseTime.Add(duration) is still in the past (e.g. bot was offline for a long time),
+        // keep adding the duration until it's in the future.
+        for !next.After(now) {
+            next = next.Add(durationToAdd)
+        }
+		return next, nil
+	}
+
+	return time.Time{}, fmt.Errorf("unsupported recurrence rule for auto-calculation: '%s'", rule)
+}
+
 
 func respondWithMessage(s *discordgo.Session, i *discordgo.InteractionCreate, message interface{}) {
 	var response *discordgo.InteractionResponseData

--- a/pb/pb.go
+++ b/pb/pb.go
@@ -5,6 +5,10 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/pocketbase/dbx"
+	"encoding/json" // For unmarshalling target_user_ids fallback
+	"strings"       // For error checking in DeleteReminder
+	"time"          // Added for reminder timestamps
+
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core" // Changed from models
 )
@@ -17,6 +21,23 @@ var (
 type ServerInfo struct {
 	UserID            string
 	ConnectionDetails string
+}
+
+// Reminder struct corresponds to the 'reminders' collection schema
+type Reminder struct {
+	ID                string    `db:"id" json:"id"` // PocketBase record ID
+	UserID            string    `db:"user_id" json:"user_id"`
+	TargetUserIDs     []string  `db:"target_user_ids" json:"target_user_ids"` // Stored as JSON in PB
+	Message           string    `db:"message" json:"message"`
+	ChannelID         string    `db:"channel_id" json:"channel_id"`
+	GuildID           string    `db:"guild_id" json:"guild_id,omitempty"`
+	ReminderTime      time.Time `db:"reminder_time" json:"reminder_time"`           // Specific time for the reminder
+	IsRecurring       bool      `db:"is_recurring" json:"is_recurring"`           // Is it a recurring reminder?
+	RecurrenceRule    string    `db:"recurrence_rule" json:"recurrence_rule,omitempty"` // e.g., "daily", "weekly"
+	NextReminderTime  time.Time `db:"next_reminder_time" json:"next_reminder_time,omitempty"` // Next time for recurring
+	LastTriggeredAt   time.Time `db:"last_triggered_at" json:"last_triggered_at,omitempty"` // Last time it was triggered
+	CreatedAt         time.Time `db:"created" json:"created"`                   // PocketBase managed
+	UpdatedAt         time.Time `db:"updated" json:"updated"`                   // PocketBase managed
 }
 
 // Init initializes the PocketBase app
@@ -130,4 +151,237 @@ func ListServersByUserID(userID string) ([]*ServerInfo, error) {
 		servers = append(servers, server)
 	}
 	return servers, nil
+}
+
+// --- Reminder Functions ---
+
+const remindersCollection = "reminders"
+
+// CreateReminder saves a new reminder to PocketBase.
+func CreateReminder(data *Reminder) error {
+	currentApp := GetApp()
+	collection, err := currentApp.FindCollectionByNameOrId(remindersCollection)
+	if err != nil {
+		log.Error("Error finding reminders collection", "error", err)
+		return err
+	}
+
+	record := core.NewRecord(collection)
+	record.Set("user_id", data.UserID)
+	record.Set("target_user_ids", data.TargetUserIDs) // PocketBase handles JSON marshalling for 'json' type fields
+	record.Set("message", data.Message)
+	record.Set("channel_id", data.ChannelID)
+	record.Set("guild_id", data.GuildID)
+	record.Set("reminder_time", data.ReminderTime.UTC().Format(time.RFC3339Nano))
+	record.Set("is_recurring", data.IsRecurring)
+	record.Set("recurrence_rule", data.RecurrenceRule)
+	if !data.NextReminderTime.IsZero() {
+		record.Set("next_reminder_time", data.NextReminderTime.UTC().Format(time.RFC3339Nano))
+	}
+
+
+	if err := currentApp.Save(record); err != nil {
+		log.Error("Error saving reminder record", "error", err)
+		return err
+	}
+	data.ID = record.Id // Set the ID from the created record
+	log.Info("Reminder record saved successfully.", "recordID", record.Id)
+	return nil
+}
+
+// GetDueReminders fetches reminders that are due to be triggered.
+// This includes non-recurring reminders where reminder_time <= now
+// and recurring reminders where next_reminder_time <= now.
+func GetDueReminders() ([]*Reminder, error) {
+	currentApp := GetApp()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	// Query for non-recurring reminders
+	filterNonRecurring := dbx.NewExp("is_recurring = false AND reminder_time <= {:now}", dbx.Params{"now": now})
+	// Query for recurring reminders
+	filterRecurring := dbx.NewExp("is_recurring = true AND next_reminder_time <= {:now}", dbx.Params{"now": now})
+
+	// Combine filters with OR
+	combinedFilter := dbx.Or(filterNonRecurring, filterRecurring)
+
+	records, err := currentApp.FindRecordsByFilter(
+		remindersCollection,
+		combinedFilter.Build(), // Build the expression to get the string
+		"+reminder_time",       // Sort by reminder_time to process earlier ones first
+		50,                     // Limit the number of reminders fetched at once
+		0,
+		combinedFilter.Params(), // Pass the parameters
+	)
+	if err != nil {
+		log.Error("Error fetching due reminders", "error", err)
+		return nil, err
+	}
+
+	var reminders []*Reminder
+	for _, record := range records {
+		r := recordToReminder(record)
+		reminders = append(reminders, r)
+	}
+	return reminders, nil
+}
+
+// UpdateReminder updates an existing reminder in PocketBase, typically for recurring reminders.
+func UpdateReminder(data *Reminder) error {
+	currentApp := GetApp()
+	record, err := currentApp.FindRecordById(remindersCollection, data.ID)
+	if err != nil {
+		log.Error("Error finding reminder to update", "recordID", data.ID, "error", err)
+		return err
+	}
+
+	record.Set("target_user_ids", data.TargetUserIDs)
+	record.Set("message", data.Message)
+	record.Set("reminder_time", data.ReminderTime.UTC().Format(time.RFC3339Nano)) // Original reminder time might change if edited
+	record.Set("is_recurring", data.IsRecurring)
+	record.Set("recurrence_rule", data.RecurrenceRule)
+
+	if !data.NextReminderTime.IsZero() {
+		record.Set("next_reminder_time", data.NextReminderTime.UTC().Format(time.RFC3339Nano))
+	} else {
+		record.Set("next_reminder_time", nil) // Clear it if zero
+	}
+	if !data.LastTriggeredAt.IsZero() {
+		record.Set("last_triggered_at", data.LastTriggeredAt.UTC().Format(time.RFC3339Nano))
+	} else {
+		record.Set("last_triggered_at", nil) // Clear it if zero
+	}
+
+
+	if err := currentApp.Save(record); err != nil {
+		log.Error("Error updating reminder record", "recordID", data.ID, "error", err)
+		return err
+	}
+	log.Info("Reminder record updated successfully.", "recordID", data.ID)
+	return nil
+}
+
+// DeleteReminder deletes a reminder from PocketBase.
+func DeleteReminder(reminderID string) error {
+	currentApp := GetApp()
+	record, err := currentApp.FindRecordById(remindersCollection, reminderID)
+	if err != nil {
+		log.Error("Error finding reminder to delete", "recordID", reminderID, "error", err)
+		// If it's already deleted or not found, we can consider it a success for this operation's intent.
+		if strings.Contains(err.Error(), "Failed to find record") { // TODO: check for specific error type if available
+			log.Warn("Reminder not found, possibly already deleted.", "recordID", reminderID)
+			return nil
+		}
+		return err
+	}
+
+	if err := currentApp.Delete(record); err != nil { // Changed from DeleteRecord to Delete
+		log.Error("Error deleting reminder record", "recordID", reminderID, "error", err)
+		return err
+	}
+	log.Info("Reminder record deleted successfully.", "recordID", reminderID)
+	return nil
+}
+
+// ListRemindersByUser fetches all active reminders for a given user.
+func ListRemindersByUser(userID string) ([]*Reminder, error) {
+	currentApp := GetApp()
+	records, err := currentApp.FindRecordsByFilter(
+		remindersCollection,
+		"user_id = {:userID}",
+		"+reminder_time", // Sort by next due time
+		0,                // No limit, get all
+		0,
+		dbx.Params{"userID": userID},
+	)
+	if err != nil {
+		log.Error("Error listing reminders by user", "userID", userID, "error", err)
+		return nil, err
+	}
+
+	var reminders []*Reminder
+	for _, record := range records {
+		r := recordToReminder(record)
+		reminders = append(reminders, r)
+	}
+	return reminders, nil
+}
+
+// Helper function to convert a PocketBase record to a Reminder struct
+func recordToReminder(record *core.Record) *Reminder {
+	r := &Reminder{
+		ID:             record.Id,
+		UserID:         record.GetString("user_id"),
+		Message:        record.GetString("message"),
+		ChannelID:      record.GetString("channel_id"),
+		GuildID:        record.GetString("guild_id"),
+		IsRecurring:    record.GetBool("is_recurring"),
+		RecurrenceRule: record.GetString("recurrence_rule"),
+	}
+
+	// PocketBase stores JSON array as string internally, Get() returns it as such.
+	// We need to unmarshal it into []string.
+	// However, the `json` field type in PocketBase should automatically handle this
+	// if the struct field is `[]string`. Let's try direct Get() first.
+	// If Get("target_user_ids") returns a string, we'll need json.Unmarshal.
+	// For now, assume PocketBase's Go driver handles this for `Get()` on json fields.
+	// Update: Record.Get() on a json field that is an array of strings might return []interface{}.
+	// We need to convert it.
+	rawTargetUserIDs := record.Get("target_user_ids")
+	if targetIDs, ok := rawTargetUserIDs.([]interface{}); ok {
+		r.TargetUserIDs = make([]string, len(targetIDs))
+		for i, v := range targetIDs {
+			if idStr, okStr := v.(string); okStr {
+				r.TargetUserIDs[i] = idStr
+			}
+		}
+	} else if targetIDsStr, okStr := rawTargetUserIDs.(string); okStr && targetIDsStr != "" {
+		// Fallback if it's a JSON string (less ideal from Get)
+		var ids []string
+		if err := json.Unmarshal([]byte(targetIDsStr), &ids); err == nil {
+			r.TargetUserIDs = ids
+		} else {
+			log.Warn("Failed to unmarshal target_user_ids string", "value", targetIDsStr, "error", err)
+		}
+	}
+
+
+	reminderTimeStr := record.GetString("reminder_time")
+	if t, err := time.Parse(time.RFC3339Nano, reminderTimeStr); err == nil {
+		r.ReminderTime = t
+	} else {
+		log.Warn("Failed to parse reminder_time", "value", reminderTimeStr, "error", err)
+	}
+
+	nextReminderTimeStr := record.GetString("next_reminder_time")
+	if t, err := time.Parse(time.RFC3339Nano, nextReminderTimeStr); err == nil && !t.IsZero() {
+		r.NextReminderTime = t
+	} else if err != nil && nextReminderTimeStr != "" { // Only log if there was a value but parsing failed
+		log.Warn("Failed to parse next_reminder_time", "value", nextReminderTimeStr, "error", err)
+	}
+
+
+	lastTriggeredAtStr := record.GetString("last_triggered_at")
+	if t, err := time.Parse(time.RFC3339Nano, lastTriggeredAtStr); err == nil && !t.IsZero() {
+		r.LastTriggeredAt = t
+	} else if err != nil && lastTriggeredAtStr != "" { // Only log if there was a value but parsing failed
+		log.Warn("Failed to parse last_triggered_at", "value", lastTriggeredAtStr, "error", err)
+	}
+
+	// PocketBase managed fields
+	r.CreatedAt, _ = time.Parse(time.RFC3339Nano, record.GetString("created"))
+	r.UpdatedAt, _ = time.Parse(time.RFC3339Nano, record.GetString("updated"))
+
+	return r
+}
+
+// GetReminderByID fetches a single reminder by its PocketBase ID.
+func GetReminderByID(reminderID string) (*Reminder, error) {
+	currentApp := GetApp()
+	record, err := currentApp.FindRecordById(remindersCollection, reminderID)
+	if err != nil {
+		// Don't log error here if it's just "not found", as that's a valid case for checks.
+		// The caller can decide to log based on context.
+		return nil, err
+	}
+	return recordToReminder(record), nil
 }


### PR DESCRIPTION
Implements a reminder system for the Discord bot using PocketBase for persistence.

Features:
- Slash commands: `/remind add`, `/remind list`, `/remind delete`.
- Add reminders for multiple users (mentions, IDs, or @me).
- Specify when to be reminded using simple relative times (e.g., "in 10m", "in 2h") and basic recurring intervals (e.g., "every 30m", "every 1d").
- List active reminders, showing ID, message, target, and next due time.
- Delete reminders by ID (only creator can delete).
- Background scheduler checks for due reminders every minute.
- Recurring reminders automatically reschedule themselves.
- Times are stored in UTC in PocketBase and displayed in the bot server's local time.

Further enhancements for time parsing (specific dates/times, timezones) and more complex recurrence rules (cron) are noted as future TODOs.