### PR TITLE
feat: Expose SSH functionality as AI tools for Gemini

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -196,6 +196,14 @@ func hasAdminRole(roles []string) bool {
 	return false
 }
 
+// CheckAdmin returns true if the user ID matches AllowedUserID or they have a matching role
+func CheckAdmin(userID string, roles []string) bool {
+	if userID == AllowedUserID {
+		return true
+	}
+	return hasAdminRole(roles)
+}
+
 func newMessage(discord *discordgo.Session, message *discordgo.MessageCreate) {
 	if message.Author.ID == discord.State.User.ID || message.Content == "" {
 		return
@@ -203,7 +211,7 @@ func newMessage(discord *discordgo.Session, message *discordgo.MessageCreate) {
 	isPrivateChannel := message.GuildID == ""
 
 	if strings.HasPrefix(message.Content, "!bit") || isPrivateChannel {
-		chatbot(discord, message.Author.ID, message.ChannelID, message.Content)
+		chatbot(discord, message.Author.ID, message.ChannelID, message.GuildID, message.Content)
 	}
 
 	if strings.HasPrefix(message.Content, "!roll") {
@@ -300,118 +308,59 @@ func commandHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			respondWithMessage(s, i, currentCryptoPrice)
 
 		case "genkey":
-			if hasAdminRole(i.Member.Roles) {
-				err := GenerateAndSaveSSHKeyPairIfNotExist()
-				response := "SSH key pair generated and saved successfully!"
-				if err != nil {
-					response = "Error generating or saving key pair."
-				}
+			if CheckAdmin(i.Member.User.ID, i.Member.Roles) {
+				response, _ := GenerateSSHKeyCore(false)
 				respondWithMessage(s, i, response)
 			} else {
 				respondWithMessage(s, i, "You are not authorized to use this command.")
 			}
 
 		case "showkey":
-			if hasAdminRole(i.Member.Roles) {
-				publicKey, err := GetPublicKey()
-				response := publicKey
-				if err != nil {
-					response = "Error fetching public key."
-				}
+			if CheckAdmin(i.Member.User.ID, i.Member.Roles) {
+				response, _ := ShowSSHPublicKeyCore()
 				respondWithMessage(s, i, response)
 			} else {
 				respondWithMessage(s, i, "You are not authorized to use this command.")
 			}
 
 		case "regenkey":
-			if hasAdminRole(i.Member.Roles) {
-				err := GenerateAndSaveSSHKeyPair()
-				response := "SSH key pair regenerated and saved successfully!"
-				if err != nil {
-					response = "Error regenerating and saving key pair."
-				}
+			if CheckAdmin(i.Member.User.ID, i.Member.Roles) {
+				response, _ := GenerateSSHKeyCore(true)
 				respondWithMessage(s, i, response)
 			} else {
 				respondWithMessage(s, i, "You are not authorized to use this command.")
 			}
 
 		case "ssh":
-			if hasAdminRole(i.Member.Roles) {
+			if CheckAdmin(i.Member.User.ID, i.Member.Roles) {
 				connectionDetails := data.Options[0].StringValue()
-				sshConn, err := SSHConnectToRemoteServer(connectionDetails)
-				response := "Connected to remote server!"
-				if err != nil {
-					response = "Error connecting to remote server."
-				} else {
-					connectionKey := fmt.Sprintf("%s:%s", i.GuildID, i.Member.User.ID)
-					sshConnections[connectionKey] = sshConn
-					serverInfo := &pb.ServerInfo{UserID: i.Member.User.ID, GuildID: i.GuildID, ConnectionDetails: connectionDetails}
-					err = pb.CreateRecord("servers", serverInfo)
-					if err != nil {
-						log.Error(err)
-						response = "Error saving server information."
-					}
-				}
+				response, _ := ConnectSSHServerCore(i.Member.User.ID, i.GuildID, connectionDetails)
 				respondWithMessage(s, i, response)
 			} else {
 				respondWithMessage(s, i, "You are not authorized to use this command.")
 			}
 
 		case "exe":
-			if hasAdminRole(i.Member.Roles) {
-				connectionKey := fmt.Sprintf("%s:%s", i.GuildID, i.Member.User.ID)
-				sshConn, ok := sshConnections[connectionKey]
-				if !ok {
-					respondWithMessage(s, i, "You are not connected to any remote server in this guild. Use /ssh first.")
-					return
-				}
+			if CheckAdmin(i.Member.User.ID, i.Member.Roles) {
 				command := data.Options[0].StringValue()
-				response, err := sshConn.ExecuteCommand(command)
-				if err != nil {
-					response = "Error executing command on remote server."
-				}
+				response, _ := ExecuteSSHCommandCore(i.Member.User.ID, i.GuildID, command)
 				respondWithMessage(s, i, response)
 			} else {
 				respondWithMessage(s, i, "You are not authorized to use this command.")
 			}
 
 		case "exit":
-			if hasAdminRole(i.Member.Roles) {
-				connectionKey := fmt.Sprintf("%s:%s", i.GuildID, i.Member.User.ID)
-				sshConn, ok := sshConnections[connectionKey]
-				if !ok {
-					respondWithMessage(s, i, "You are not connected to any remote server in this guild. Use /ssh first.")
-					return
-				}
-				sshConn.Close()
-				delete(sshConnections, connectionKey)
-				respondWithMessage(s, i, "SSH connection closed.")
+			if CheckAdmin(i.Member.User.ID, i.Member.Roles) {
+				response, _ := CloseSSHConnectionCore(i.Member.User.ID, i.GuildID)
+				respondWithMessage(s, i, response)
 			} else {
 				respondWithMessage(s, i, "You are not authorized to use this command.")
 			}
 
 		case "list":
-			if hasAdminRole(i.Member.Roles) {
-				if i.GuildID == "" {
-					respondWithMessage(s, i, "This command can only be used in a server.")
-					return
-				}
-				servers, err := pb.ListServersByUserIDAndGuildID(i.Member.User.ID, i.GuildID)
-				if err != nil {
-					log.Errorf("Error listing servers for user %s in guild %s: %v", i.Member.User.ID, i.GuildID, err)
-					respondWithMessage(s, i, "Could not retrieve server list. Please try again later.")
-					return
-				}
-				if len(servers) == 0 {
-					respondWithMessage(s, i, "You don't have any saved servers in this guild.")
-					return
-				}
-				var serverListMessage strings.Builder
-				serverListMessage.WriteString("Saved servers in this guild:\n")
-				for _, server := range servers {
-					serverListMessage.WriteString(fmt.Sprintf("- `%s`\n", server.ConnectionDetails))
-				}
-				respondWithMessage(s, i, serverListMessage.String())
+			if CheckAdmin(i.Member.User.ID, i.Member.Roles) {
+				response, _ := ListSSHServersCore(i.Member.User.ID, i.GuildID)
+				respondWithMessage(s, i, response)
 			} else {
 				respondWithMessage(s, i, "You are not authorized to use this command.")
 			}

--- a/bot/chat.go
+++ b/bot/chat.go
@@ -30,6 +30,8 @@ Do NOT remove spaces between words in time expressions. Always use the exact for
 
 If a user requests a reminder for a specific date/time and it is not supported, offer to set a reminder for the equivalent duration instead (e.g., "Would you like me to set a reminder for 'in 24 hours' instead?").
 
+You also have the capability to manage SSH connections and execute commands on remote servers using the SSH tools provided. To execute commands, you must first connect to a server. You can also generate and show SSH keys. Note that only authorized users (admins) can use SSH tools. If an SSH tool fails due to lack of authorization, politely inform the user.
+
 If a tool returns an error message (as plain text), immediately reply to the user with that error and do not call the tool again unless the user asks for another attempt.
 
 After calling a tool, always reply to the user in natural language summarizing the result.
@@ -160,7 +162,7 @@ func handleGeminiError(err error, session *discordgo.Session, channelID string) 
 	}
 }
 
-func chatbot(session *discordgo.Session, userID string, channelID string, userMessageContent string) {
+func chatbot(session *discordgo.Session, userID string, channelID string, guildID string, userMessageContent string) {
 	if geminiClient == nil {
 		log.Error("Gemini client is not initialized.")
 		_, _ = session.ChannelMessageSend(channelID, "Sorry, the chat service is not properly configured.")
@@ -196,12 +198,15 @@ func chatbot(session *discordgo.Session, userID string, channelID string, userMe
 	}
 	history = append(history, userMessage)
 
+	// Combine tools
+	allTools := append(ReminderTools, SSHTools...)
+
 	// Prepare config with system instruction and tools
 	config := &genai.GenerateContentConfig{
 		SystemInstruction: &genai.Content{
 			Parts: []*genai.Part{genai.NewPartFromText(SystemInstruction)},
 		},
-		Tools: ReminderTools,
+		Tools: allTools,
 	}
 
 	// Generate content with conversation history
@@ -255,7 +260,7 @@ func chatbot(session *discordgo.Session, userID string, channelID string, userMe
 		history = append(history, functionCallContent)
 
 		// Handle the function call
-		part, err := HandleFunctionCallWithContext(session, nil, fc, userID, channelID)
+		part, err := HandleFunctionCallWithContext(session, nil, fc, userID, channelID, guildID)
 		if err != nil {
 			log.Errorf("Error handling function call: %v", err)
 			handleGeminiError(err, session, channelID)

--- a/bot/genai_tools.go
+++ b/bot/genai_tools.go
@@ -7,6 +7,71 @@ import (
 	"google.golang.org/genai"
 )
 
+// SSHTools defines the tools available to the Gemini model for SSH capabilities.
+var SSHTools = []*genai.Tool{
+	{
+		FunctionDeclarations: []*genai.FunctionDeclaration{
+			{
+				Name:        "generate_ssh_key",
+				Description: "Generates and saves a new SSH key pair. Fails if the user is not an admin.",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"regenerate": {
+							Type:        genai.TypeBoolean,
+							Description: "If true, overwrites any existing keys. If false, only generates if keys do not already exist.",
+						},
+					},
+					Required: []string{"regenerate"},
+				},
+			},
+			{
+				Name:        "show_ssh_public_key",
+				Description: "Shows the bot's public SSH key so it can be added to a remote server. Fails if the user is not an admin.",
+				Parameters: &genai.Schema{Type: genai.TypeObject, Properties: map[string]*genai.Schema{}},
+			},
+			{
+				Name:        "connect_ssh_server",
+				Description: "Connects to a remote server via SSH. Fails if the user is not an admin.",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"connection_details": {
+							Type:        genai.TypeString,
+							Description: "Connection details in the format username@remote-host:port",
+						},
+					},
+					Required: []string{"connection_details"},
+				},
+			},
+			{
+				Name:        "execute_ssh_command",
+				Description: "Executes a command on the currently connected SSH server. Fails if the user is not an admin.",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"command": {
+							Type:        genai.TypeString,
+							Description: "The command to execute on the remote server (e.g., 'ls -la', 'uptime').",
+						},
+					},
+					Required: []string{"command"},
+				},
+			},
+			{
+				Name:        "close_ssh_connection",
+				Description: "Closes the current SSH connection. Fails if the user is not an admin.",
+				Parameters: &genai.Schema{Type: genai.TypeObject, Properties: map[string]*genai.Schema{}},
+			},
+			{
+				Name:        "list_ssh_servers",
+				Description: "Lists saved SSH servers for this guild. Fails if the user is not an admin.",
+				Parameters: &genai.Schema{Type: genai.TypeObject, Properties: map[string]*genai.Schema{}},
+			},
+		},
+	},
+}
+
 // ReminderTools defines the tools available to the Gemini model for reminders.
 var ReminderTools = []*genai.Tool{
 	{
@@ -65,8 +130,20 @@ If a specific time is not supported, offer to set a reminder for the equivalent 
 	},
 }
 
+func authorizeSSH(s *discordgo.Session, guildID, userID string) bool {
+	// Attempt to get the member to check roles if we have a session and guildID
+	if s != nil && guildID != "" {
+		member, err := s.GuildMember(guildID, userID)
+		if err == nil {
+			return CheckAdmin(userID, member.Roles)
+		}
+	}
+	// Fallback to checking just the userID
+	return CheckAdmin(userID, nil)
+}
+
 // HandleFunctionCallWithContext processes a function call from the Gemini model with explicit user/channel context.
-func HandleFunctionCallWithContext(s *discordgo.Session, i *discordgo.InteractionCreate, call *genai.FunctionCall, userID, channelID string) (*genai.Part, error) {
+func HandleFunctionCallWithContext(s *discordgo.Session, i *discordgo.InteractionCreate, call *genai.FunctionCall, userID, channelID, guildID string) (*genai.Part, error) {
 	switch call.Name {
 	case "add_reminder":
 		who, _ := call.Args["who"].(string)
@@ -122,6 +199,69 @@ func HandleFunctionCallWithContext(s *discordgo.Session, i *discordgo.Interactio
 				},
 			},
 		}, nil
+	case "generate_ssh_key":
+		if !authorizeSSH(s, guildID, userID) {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": "You are not authorized to use SSH commands."}}}, nil
+		}
+		regenerate, _ := call.Args["regenerate"].(bool)
+		resp, err := GenerateSSHKeyCore(regenerate)
+		if err != nil {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": resp}}}, nil
+		}
+		return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "success", "message": resp}}}, nil
+
+	case "show_ssh_public_key":
+		if !authorizeSSH(s, guildID, userID) {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": "You are not authorized to use SSH commands."}}}, nil
+		}
+		resp, err := ShowSSHPublicKeyCore()
+		if err != nil {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": resp}}}, nil
+		}
+		return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "success", "message": resp}}}, nil
+
+	case "connect_ssh_server":
+		if !authorizeSSH(s, guildID, userID) {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": "You are not authorized to use SSH commands."}}}, nil
+		}
+		connectionDetails, _ := call.Args["connection_details"].(string)
+		resp, err := ConnectSSHServerCore(userID, guildID, connectionDetails)
+		if err != nil {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": resp}}}, nil
+		}
+		return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "success", "message": resp}}}, nil
+
+	case "execute_ssh_command":
+		if !authorizeSSH(s, guildID, userID) {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": "You are not authorized to use SSH commands."}}}, nil
+		}
+		command, _ := call.Args["command"].(string)
+		resp, err := ExecuteSSHCommandCore(userID, guildID, command)
+		if err != nil {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": resp}}}, nil
+		}
+		return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "success", "message": resp}}}, nil
+
+	case "close_ssh_connection":
+		if !authorizeSSH(s, guildID, userID) {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": "You are not authorized to use SSH commands."}}}, nil
+		}
+		resp, err := CloseSSHConnectionCore(userID, guildID)
+		if err != nil {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": resp}}}, nil
+		}
+		return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "success", "message": resp}}}, nil
+
+	case "list_ssh_servers":
+		if !authorizeSSH(s, guildID, userID) {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": "You are not authorized to use SSH commands."}}}, nil
+		}
+		resp, err := ListSSHServersCore(userID, guildID)
+		if err != nil {
+			return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "error", "message": resp}}}, nil
+		}
+		return &genai.Part{FunctionResponse: &genai.FunctionResponse{Name: call.Name, Response: map[string]interface{}{"status": "success", "message": resp}}}, nil
+
 	default:
 		return nil, fmt.Errorf("unknown function call: %s", call.Name)
 	}

--- a/bot/ssh_core.go
+++ b/bot/ssh_core.go
@@ -1,0 +1,116 @@
+package bot
+
+import (
+	"bitbot/pb"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/log"
+)
+
+// GenerateSSHKeyCore generates and saves a new SSH key pair.
+func GenerateSSHKeyCore(regenerate bool) (string, error) {
+	var err error
+	if regenerate {
+		err = GenerateAndSaveSSHKeyPair()
+	} else {
+		err = GenerateAndSaveSSHKeyPairIfNotExist()
+	}
+
+	if err != nil {
+		log.Errorf("Error generating SSH key: %v", err)
+		return "Error generating or saving key pair.", err
+	}
+	return "SSH key pair generated and saved successfully!", nil
+}
+
+// ShowSSHPublicKeyCore returns the current public SSH key.
+func ShowSSHPublicKeyCore() (string, error) {
+	publicKey, err := GetPublicKey()
+	if err != nil {
+		log.Errorf("Error fetching public SSH key: %v", err)
+		return "Error fetching public key.", err
+	}
+	return publicKey, nil
+}
+
+// ConnectSSHServerCore connects to an SSH server and saves the connection.
+func ConnectSSHServerCore(userID, guildID, connectionDetails string) (string, error) {
+	sshConn, err := SSHConnectToRemoteServer(connectionDetails)
+	if err != nil {
+		log.Errorf("Error connecting to remote server %s: %v", connectionDetails, err)
+		return fmt.Sprintf("Error connecting to remote server: %v", err), err
+	}
+
+	connectionKey := fmt.Sprintf("%s:%s", guildID, userID)
+	sshConnections[connectionKey] = sshConn
+
+	serverInfo := &pb.ServerInfo{UserID: userID, GuildID: guildID, ConnectionDetails: connectionDetails}
+	err = pb.CreateRecord("servers", serverInfo)
+	if err != nil {
+		log.Errorf("Error saving server information to pb: %v", err)
+		// We can still consider the connection successful even if saving fails.
+		return "Connected to remote server! (Warning: Failed to save server to database)", nil
+	}
+
+	return "Connected to remote server and saved to database!", nil
+}
+
+// ExecuteSSHCommandCore executes a command on an active SSH connection.
+func ExecuteSSHCommandCore(userID, guildID, command string) (string, error) {
+	connectionKey := fmt.Sprintf("%s:%s", guildID, userID)
+	sshConn, ok := sshConnections[connectionKey]
+	if !ok {
+		return "You are not connected to any remote server in this context. Please connect first.", fmt.Errorf("not connected")
+	}
+
+	response, err := sshConn.ExecuteCommand(command)
+	if err != nil {
+		log.Errorf("Error executing command '%s' on %s: %v", command, connectionKey, err)
+		return fmt.Sprintf("Error executing command on remote server: %v", err), err
+	}
+
+	// If response is too long for discord/gemini, we might need to truncate
+	// but we'll let the caller or Gemini handle truncation for now.
+	if response == "" {
+		return "(Command executed successfully, no output)", nil
+	}
+	return response, nil
+}
+
+// CloseSSHConnectionCore closes an active SSH connection.
+func CloseSSHConnectionCore(userID, guildID string) (string, error) {
+	connectionKey := fmt.Sprintf("%s:%s", guildID, userID)
+	sshConn, ok := sshConnections[connectionKey]
+	if !ok {
+		return "You are not connected to any remote server in this context.", fmt.Errorf("not connected")
+	}
+
+	sshConn.Close()
+	delete(sshConnections, connectionKey)
+	return "SSH connection closed.", nil
+}
+
+// ListSSHServersCore lists previously saved SSH servers for a user/guild.
+func ListSSHServersCore(userID, guildID string) (string, error) {
+	if guildID == "" {
+		return "Listing servers is currently only supported within a server context.", fmt.Errorf("missing guildID")
+	}
+
+	servers, err := pb.ListServersByUserIDAndGuildID(userID, guildID)
+	if err != nil {
+		log.Errorf("Error listing servers for user %s in guild %s: %v", userID, guildID, err)
+		return "Could not retrieve server list.", err
+	}
+
+	if len(servers) == 0 {
+		return "You don't have any saved servers in this guild.", nil
+	}
+
+	var serverListMessage strings.Builder
+	serverListMessage.WriteString("Saved servers in this guild:\n")
+	for _, server := range servers {
+		serverListMessage.WriteString(fmt.Sprintf("- `%s`\n", server.ConnectionDetails))
+	}
+	return serverListMessage.String(), nil
+}


### PR DESCRIPTION
This pull request introduces the ability for the Gemini AI agent to manage and use SSH connections autonomously when interacting with users via chat. It leverages existing SSH functionality that was previously only available via specific slash commands (`/ssh`, `/exe`, etc.) and exposes it as a set of tools in the GenAI SDK config.

Key additions:
- Created `SSHTools` covering key generation, public key viewing, connection establishment, execution of commands, connection closing, and server listing.
- Core logic extracted to `ssh_core.go` to support both legacy slash commands and new AI tool execution.
- Only authorized users (matching `AllowedUserID` or having an admin role) can use these tools.
- Handled error responses for function calls to strictly follow the Gemini API contract by returning a `FunctionResponse` rather than raw text on failure.

---
*PR created automatically by Jules for task [5893043681622362690](https://jules.google.com/task/5893043681622362690) started by @kristiand00*